### PR TITLE
feat(jupyter): accept message type in jupyter io publish call

### DIFF
--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -119,6 +119,7 @@ deno_core::extension!(deno_jupyter,
 #[op2(async)]
 pub async fn op_jupyter_send_io(
   state: Rc<RefCell<OpState>>,
+  #[string] message_type: String,
   #[serde] content: serde_json::Value,
 ) -> Result<(), AnyError> {
   let (iopub_socket, last_execution_request) = {
@@ -133,7 +134,7 @@ pub async fn op_jupyter_send_io(
 
   if let Some(last_request) = last_execution_request.borrow().clone() {
     last_request
-      .new_message("display_data")
+      .new_message(&message_type)
       .with_content(content)
       .send(&mut *iopub_socket.lock().await)
       .await?;

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -179,8 +179,8 @@ const denoNsUnstable = {
   KvU64: kv.KvU64,
   KvListIterator: kv.KvListIterator,
   jupyter: {
-    async sendIo(content) {
-      await core.opAsync("op_jupyter_send_io", content);
+    async sendIo(msg_type, content) {
+      await core.opAsync("op_jupyter_send_io", msg_type, content);
     },
   },
 };


### PR DESCRIPTION
Accept message type as the first argument so we can update displays. Here's an example of what people can do with this!

![update-display](https://github.com/bartlomieju/deno/assets/836375/da3d5094-5e05-4213-b07b-6b4545554686)
